### PR TITLE
Print errors and make JSON output indented

### DIFF
--- a/src/com/riotgames/mondev/JMXDiscovery.java
+++ b/src/com/riotgames/mondev/JMXDiscovery.java
@@ -106,7 +106,7 @@ public class JMXDiscovery {
 			JSONObject out = new JSONObject();
 			out.put("data", data);
 
-			return out.toString();
+			return out.toString(4);
 		} finally {
 			try { if (null != jmxc) jmxc.close(); } catch (java.io.IOException exception) { }
 


### PR DESCRIPTION
As I'm not entirely used to the MBean world, the fact that there was no error printing at all was not so helpful :-)

In addition, the output was rather cryptic until I added some indentation. I've tested against Zabbix 2.2, and the indended/prettyprinted JSON is still accepted and used correctly.
