### PR TITLE
used toString() instead of getCanonicalName() because getCanonicalNam…

### DIFF
--- a/src/com/riotgames/mondev/JMXDiscovery.java
+++ b/src/com/riotgames/mondev/JMXDiscovery.java
@@ -86,7 +86,7 @@ public class JMXDiscovery {
 				// Build the standing info, description and object path
 				MBeanInfo mbi = mbsc.getMBeanInfo(beanName);
 				bean.put("{#JMXDESC}", mbi.getDescription());
-				bean.put("{#JMXOBJ}", beanName.getCanonicalName());
+				bean.put("{#JMXOBJ}", beanName.toString());
 
 				// Build a list of all the MBean properties as {#PROP<NAME>}
 				Hashtable<String, String> pt = beanName.getKeyPropertyList();


### PR DESCRIPTION
…e reversed the order of the mbean object 'name' and 'type' key properties that was needed for JMX to successfully get information from Kafka

http://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html
